### PR TITLE
Fit plane elastic: xyz-uv, uv-xyz mapping, and image transformation

### DIFF
--- a/plane/fit_plane_elastic.py
+++ b/plane/fit_plane_elastic.py
@@ -2,6 +2,7 @@ import numpy as np
 import json
 from scipy.interpolate import RBFInterpolator
 from scipy.ndimage import map_coordinates
+from sklearn.metrics import mean_absolute_error
 
 class FitPlaneElastic:
     """
@@ -170,3 +171,14 @@ class FitPlaneElastic:
             )
 
         return transformed_image
+    
+    def get_template_center_positions_distance_metrics(self, uv_pix, xyz_mm):
+        """ 
+        uv_pix: coordinates in pixels, array shape (2,n)
+        xyz_mm: coordinates in mm, array shape (3,n)
+        Returns in plane and out of plane distances between mapped uv points and corresponding xyz points.
+        """
+        uv_to_xyz = np.squeeze(np.array([self.get_xyz_from_uv(p) for p in uv_pix]))
+        in_plane = np.sqrt(np.sum(mean_absolute_error(uv_to_xyz[:,:2], xyz_mm[:,:2], multioutput='raw_values')**2))
+        out_plane = np.mean(np.abs(uv_to_xyz[:, 2] - xyz_mm[:, 2])) # Avg differences on z
+        return in_plane, out_plane

--- a/plane/fit_plane_elastic.py
+++ b/plane/fit_plane_elastic.py
@@ -24,7 +24,7 @@ class FitPlaneElastic:
             template_positions_uv_pix: For each photobleach barcode, find the center position in pixels. This is an
                 array of these center points [[x1, y1], [x2, y2],..., [xn, yn]] with shape (n,2)
             template_positions_xyz_mm: An array [[x1, y1, z1],..., [xn, yn, zn]] of shape (n,3) containing points defining the 
-                position (in um) of the locations that each of the points in template_center_positions_uv_pix should map to. 
+                position (in um) of the locations that each of the points in template_positions_uv_pix should map to. 
                 These points can be obtained from the photobleaching script.
             print_inputs: prints to screen the inputs of the function for debug purposes.
         """
@@ -33,11 +33,11 @@ class FitPlaneElastic:
         template_positions_xyz_mm = np.array(template_positions_xyz_mm)
         if (template_positions_uv_pix.shape[0] != template_positions_xyz_mm.shape[0]):
             raise ValueError("Number of points should be the same between " + 
-                "template_center_positions_uv_pix, template_center_positions_xyz_mm")
+                "template_positions_uv_pix, template_positions_xyz_mm")
         if template_positions_uv_pix.shape[1] != 2:
-            raise ValueError("Number of elements in template_center_positions_uv_pix should be two")
+            raise ValueError("Number of elements in template_positions_uv_pix should be two")
         if template_positions_xyz_mm.shape[1] != 3:
-            raise ValueError("Number of elements in template_center_positions_xyz_mm should be three")
+            raise ValueError("Number of elements in template_positions_xyz_mm should be three")
         
         # Print inputs
         if print_inputs:

--- a/plane/fit_plane_elastic.py
+++ b/plane/fit_plane_elastic.py
@@ -1,98 +1,155 @@
-import json
 import numpy as np
-from scipy.optimize import minimize
-from sklearn.metrics import mean_absolute_error
-import cv2
+import json
 from scipy.interpolate import RBFInterpolator
 from scipy.ndimage import map_coordinates
 
 class FitPlaneElastic:
+    """
+    A class to perform 2D-to-3D Thin Plate Spline (TPS) transformations using RBFInterpolator.
+    Supports forward mapping (uv -> xyz) and reverse mapping (xyz -> uv) using separate interpolators.
+    """
     
-    """ Begin constractor methods """
-    def __init__(self, tps_interpolator=None, control_points=None):
-        self.tps_interpolator = tps_interpolator
-        self.control_points = control_points
-        if not (self.control_points is None):
+    def __init__(self, forward_interpolator=None, inverse_interpolator=None, control_points=None):
+        """
+        Initialize the FitPlaneElastic class.
+
+        Args:
+            forward_interpolator: An RBFInterpolator object for forward mapping (uv -> xyz).
+            inverse_interpolator: An RBFInterpolator object for reverse mapping (xyz -> uv).
+            control_points: The control points used to initialize the interpolators.
+        """
+        self.forward_interpolator = forward_interpolator  # Forward interpolator (uv -> xyz)
+        self.inverse_interpolator = inverse_interpolator  # Inverse interpolator (xyz -> uv)
+        self.control_points = control_points  # Control points (uv and xyz)
+        if self.control_points is not None:
             self.control_points = np.array(self.control_points)
     
     @classmethod
-    def from_points(
-        cls, template_positions_uv_pix, template_positions_xyz_mm, print_inputs = False):
+    def from_points(cls, template_positions_uv_pix, template_positions_xyz_mm, print_inputs=False):
         """
-        This function initializes a FitPlaneElastic by applying Thin Plate Spline on a list of points.
+        Initialize a FitPlaneElastic object using control points.
 
-        INPUTS:
-            template_positions_uv_pix: For each photobleach barcode, find the center position in pixels. This is an
-                array of these center points [[x1, y1], [x2, y2],..., [xn, yn]] with shape (n,2)
-            template_positions_xyz_mm: An array [[x1, y1, z1],..., [xn, yn, zn]] of shape (n,3) containing points defining the 
-                position (in um) of the locations that each of the points in template_positions_uv_pix should map to. 
-                These points can be obtained from the photobleaching script.
-            print_inputs: prints to screen the inputs of the function for debug purposes.
+        Args:
+            template_positions_uv_pix: 2D source points (uv) as a numpy array of shape (n, 2).
+            template_positions_xyz_mm: 3D target points (xyz) as a numpy array of shape (n, 3).
+            print_inputs: If True, print the inputs for debugging.
+
+        Returns:
+            A FitPlaneElastic object.
         """
-        # Input check
+        # Input validation
         template_positions_uv_pix = np.array(template_positions_uv_pix)
         template_positions_xyz_mm = np.array(template_positions_xyz_mm)
-        if (template_positions_uv_pix.shape[0] != template_positions_xyz_mm.shape[0]):
-            raise ValueError("Number of points should be the same between " + 
-                "template_positions_uv_pix, template_positions_xyz_mm")
+        if template_positions_uv_pix.shape[0] != template_positions_xyz_mm.shape[0]:
+            raise ValueError("Number of points should be the same between template_positions_uv_pix and template_positions_xyz_mm")
         if template_positions_uv_pix.shape[1] != 2:
-            raise ValueError("Number of elements in template_positions_uv_pix should be two")
+            raise ValueError("template_positions_uv_pix must have shape (n, 2)")
         if template_positions_xyz_mm.shape[1] != 3:
-            raise ValueError("Number of elements in template_positions_xyz_mm should be three")
-        
-        # Print inputs
+            raise ValueError("template_positions_xyz_mm must have shape (n, 3)")
+
+        # Print inputs for debugging
         if print_inputs:
-            txt = ("FitPlane.from_template_centers(" +
-                   json.dumps(template_positions_uv_pix.tolist()) + "," +
-                   json.dumps(template_positions_xyz_mm.tolist()))   
-            txt += ')'
-            print(txt)
+            print("template_positions_uv_pix:\n", template_positions_uv_pix)
+            print("template_positions_xyz_mm:\n", template_positions_xyz_mm)
 
-        # Compute Thin Plate Spline transformation
-        x = template_positions_xyz_mm[:, 0]
-        y = template_positions_xyz_mm[:, 1]
-        z = template_positions_xyz_mm[:, 2]
-
-        # TPS interpolators for each x, y, z 
-        tps_interpolator = RBFInterpolator(
-            template_positions_uv_pix,  # 2D input points (u, v)
-            template_positions_xyz_mm,  # 3D target points (x, y, z)
+        # Create forward interpolator (uv -> xyz)
+        forward_interpolator = RBFInterpolator(
+            template_positions_uv_pix,  # 2D source points (uv)
+            template_positions_xyz_mm,  # 3D target points (xyz)
             kernel='thin_plate_spline',  # Use Thin Plate Spline kernel
             neighbors=None  # Use all points for interpolation
         )
+
+        # Create inverse interpolator (xyz -> uv)
+        inverse_interpolator = RBFInterpolator(
+            template_positions_xyz_mm[:, :2],  # Use only x and y for inverse (2D)
+            template_positions_uv_pix,  # 2D target points (uv)
+            kernel='thin_plate_spline',  # Use Thin Plate Spline kernel
+            neighbors=None  # Use all points for interpolation
+        )
+
+        # Store control points
         control_points = template_positions_uv_pix
 
-        return cls(tps_interpolator, control_points)
+        return cls(forward_interpolator, inverse_interpolator, control_points)
     
     def get_xyz_from_uv(self, uv_pix):
-        """ Map a 2D point (u,v) to 3D (x,y,z) space using TPS interpolation. """
+        """
+        Map 2D uv coordinates to 3D xyz coordinates using the forward interpolator.
+
+        Args:
+            uv_pix: 2D uv coordinates as a numpy array of shape (n, 2).
+
+        Returns:
+            3D xyz coordinates as a numpy array of shape (n, 3).
+        """
         uv_pix = np.array(uv_pix)
-        xyz = self.tps_interpolator(uv_pix)  # Add batch dimension
-        return xyz
-  
+        if uv_pix.ndim == 1:
+            uv_pix = uv_pix[np.newaxis, :]  # Add batch dimension for single point
+        return self.forward_interpolator(uv_pix)
+    
+    def get_uv_from_xyz(self, xyz_mm):
+        """
+        Map 3D xyz coordinates to 2D uv coordinates using the inverse interpolator.
+
+        Args:
+            xyz_mm: 3D xyz coordinates as a numpy array of shape (n, 3).
+
+        Returns:
+            2D uv coordinates as a numpy array of shape (n, 2).
+        """
+        xyz_mm = np.array(xyz_mm)
+        if xyz_mm.ndim == 1:
+            xyz_mm = xyz_mm[np.newaxis, :]  # Add batch dimension for single point
+        return self.inverse_interpolator(xyz_mm[:, :2])  # Use only x and y for inverse
+    
     def image_to_physical(self, cv2_image, x_range_mm=[-1, 1], y_range_mm=[-1, 1], pixel_size_mm=1e-3):
-        """ Project a 2D image to 3D physical space within range x_range_mm, y_range_mm using TPS interpolation."""
+        """
+        Project a 2D image to 3D physical space within range x_range_mm, y_range_mm using TPS interpolation.
+
+        Args:
+            cv2_image: The source image (2D or 3D RGB) to be transformed.
+            x_range_mm: The physical range in the x-direction (in mm).
+            y_range_mm: The physical range in the y-direction (in mm).
+            pixel_size_mm: The size of each pixel in mm.
+
+        Returns:
+            transformed_image: The transformed image in physical space.
+        """
         # Input checks
         x_range_mm = np.array(x_range_mm)
         y_range_mm = np.array(y_range_mm)
 
-        x_range_px = x_range_mm / pixel_size_mm
-        y_range_px = y_range_mm / pixel_size_mm
+        if x_range_mm[1] <= x_range_mm[0] or y_range_mm[1] <= y_range_mm[0]:
+            raise ValueError("Invalid range: x_range_mm and y_range_mm must be increasing")
 
-        # Define the destination grid in px
-        x_px = np.linspace(x_range_px[0], x_range_px[1]-1, int(x_range_px[1] - x_range_px[0]))
-        y_px = np.linspace(y_range_px[0], y_range_px[1]-1, int((y_range_px[1] - y_range_px[0])))
-        xx, yy = np.meshgrid(x_px, y_px)
+        if pixel_size_mm <= 0:
+            raise ValueError("pixel_size_mm must be positive")
 
-        # Map uv to xyz
-        uv_points = np.vstack([xx.ravel(), yy.ravel()]).T
-        xyz_points = self.tps_interpolator(uv_points)
+        # Calculate image dimensions
+        width_px = int((x_range_mm[1] - x_range_mm[0]) / pixel_size_mm)
+        height_px = int((y_range_mm[1] - y_range_mm[0]) / pixel_size_mm)
 
-        mapped_u = xyz_points[:, 0].reshape(xx.shape)
-        mapped_v = xyz_points[:, 1].reshape(xx.shape)
+        # Initialize black image
+        transformed_image = np.zeros_like(cv2_image)
 
-        mapped_u = np.round(mapped_u / pixel_size_mm)
-        mapped_v = np.round(mapped_v / pixel_size_mm)
+        # Define the destination grid in physical coordinates
+        x_physical = np.linspace(x_range_mm[0], (x_range_mm[1]/pixel_size_mm - 1) * pixel_size_mm, width_px)
+        y_physical = np.linspace(y_range_mm[0], (y_range_mm[1]/pixel_size_mm - 1) * pixel_size_mm, height_px)
+        xx_physical, yy_physical = np.meshgrid(x_physical, y_physical)
+
+        # Flatten the grid for TPS transformation
+        physical_points = np.vstack([xx_physical.ravel(), yy_physical.ravel()]).T
+
+        # Map physical coordinates to UV coordinates using the inverse interpolator
+        uv_points = self.get_uv_from_xyz(physical_points)
+
+        # Reshape UV coordinates to match the destination grid
+        uv_points = uv_points.reshape((height_px, width_px, 2))
+
+        # Extract U and V coordinates
+        u_coords = uv_points[:, :, 0]
+        v_coords = uv_points[:, :, 1]
 
         # Handle RGB images
         if len(cv2_image.shape) == 3:
@@ -100,23 +157,22 @@ class FitPlaneElastic:
             warped_channels = [
                 map_coordinates(
                     cv2_image[:, :, channel],  # Extract one channel
-                    [mapped_v, mapped_u],  # Use the same coordinates for all channels
-                    order=1,  
-                    mode='constant', 
-                    cval=0.0 
+                    [v_coords, u_coords],     # Use UV coordinates
+                    order=1,                  # Bilinear interpolation
+                    mode='constant',          # Fill with zeros outside boundaries
+                    cval=0.0                 # Fill value
                 )
                 for channel in range(cv2_image.shape[2])  # Loop over channels
             ]
             # Stack the warped channels back into a 3D image
             transformed_image = np.stack(warped_channels, axis=-1)
-        else: # Grayscale
+        else:  # Grayscale
             transformed_image = map_coordinates(
                 cv2_image,
-                [mapped_v, mapped_u],  
-                order=1, 
-                mode='constant',  
-                cval=0.0 
+                [v_coords, u_coords],
+                order=1,
+                mode='constant',
+                cval=0.0
             )
 
-        return transformed_image    
-    
+        return transformed_image

--- a/plane/fit_plane_elastic.py
+++ b/plane/fit_plane_elastic.py
@@ -79,19 +79,20 @@ class FitPlaneElastic:
         x_range_px = x_range_mm / pixel_size_mm
         y_range_px = y_range_mm / pixel_size_mm
 
-        # Define the destination grid 
-        x_px = np.linspace(x_range_px[0], x_range_px[1], int(x_range_px[1]-x_range_px[0])+1)
-        y_px = np.linspace(y_range_px[0], y_range_px[1], int((y_range_px[1] - y_range_px[0]))+1)
+        # Define the destination grid in px
+        x_px = np.linspace(x_range_px[0], x_range_px[1]-1, int(x_range_px[1] - x_range_px[0]))
+        y_px = np.linspace(y_range_px[0], y_range_px[1]-1, int((y_range_px[1] - y_range_px[0])))
         xx, yy = np.meshgrid(x_px, y_px)
 
-        # Map uv to xyz in mm
+        # Map uv to xyz
         uv_points = np.vstack([xx.ravel(), yy.ravel()]).T
         xyz_points = self.tps_interpolator(uv_points)
+
         mapped_u = xyz_points[:, 0].reshape(xx.shape)
         mapped_v = xyz_points[:, 1].reshape(xx.shape)
 
-        mapped_u = (mapped_u) / pixel_size_mm
-        mapped_v = (mapped_v ) / pixel_size_mm
+        mapped_u = np.round(mapped_u / pixel_size_mm)
+        mapped_v = np.round(mapped_v / pixel_size_mm)
 
         # Handle RGB images
         if len(cv2_image.shape) == 3:

--- a/plane/fit_plane_elastic.py
+++ b/plane/fit_plane_elastic.py
@@ -8,11 +8,15 @@ from scipy.interpolate import Rbf, griddata
 class FitPlaneElastic:
     
     """ Begin constractor methods """
-    def __init__(self, tps_weights=None, control_points=None):
-        self.tps_weights = tps_weights
+    def __init__(self, tps_x=None, tps_y=None, tps_z=None, control_points=None):
+        self.tps_x = tps_x
+        self.tps_y = tps_y
+        self.tps_z = tps_z
         self.control_points = control_points
-        if not (self.tps_weights is None or self.control_points is None):
-            self.tps_weights = np.array(self.tps_weights)
+        if not (self.tps_x is None or self.tps_y is None or self.tps_z is None or self.control_points is None):
+            self.tps_x = np.array(tps_x)
+            self.tps_y = np.array(tps_y)
+            self.tps_z = np.array(tps_z)
             self.control_points = np.array(self.control_points)
     
     @classmethod
@@ -57,9 +61,6 @@ class FitPlaneElastic:
         tps_x = Rbf(template_positions_uv_pix[:, 0], template_positions_uv_pix[:, 1], x, function='thin_plate')
         tps_y = Rbf(template_positions_uv_pix[:, 0], template_positions_uv_pix[:, 1], y, function='thin_plate')
         tps_z = Rbf(template_positions_uv_pix[:, 0], template_positions_uv_pix[:, 1], z, function='thin_plate')
-
-        # Store weights and control points
-        tps_weights = np.vstack([tps_x.nodes, tps_y.nodes, tps_z.nodes])
         control_points = template_positions_uv_pix
 
-        return cls(tps_weights, control_points)
+        return cls(tps_x.nodes, tps_y.nodes, tps_z.nodes, control_points)

--- a/plane/fit_plane_elastic.py
+++ b/plane/fit_plane_elastic.py
@@ -1,0 +1,48 @@
+import json
+import numpy as np
+from scipy.optimize import minimize
+from sklearn.metrics import mean_absolute_error
+import cv2
+
+class FitPlaneElastic:
+    
+    """ Begin constractor methods """
+    def __init__(self, tps_weights=None, control_points=None):
+        self.tps_weights = tps_weights
+        self.control_points = control_points
+        if self.tps_weights and self.control_points:
+            self.tps_weights = np.array(self.tps_weights)
+            self.control_points = np.array(self.control_points)
+    
+    @classmethod
+    def from_points(
+        cls, template_positions_uv_pix, template_positions_xyz_mm, print_inputs = False):
+        """
+        This function initializes a FitPlaneElastic by a list of points.
+
+        INPUTS:
+            template_positions_uv_pix: For each photobleach barcode, find the center position in pixels. This is an
+                array of these center points [[x1, y1], [x2, y2],..., [xn, yn]] with shape (n,2)
+            template_positions_xyz_mm: An array [[x1, y1, z1],..., [xn, yn, zn]] of shape (n,3) containing points defining the 
+                position (in um) of the locations that each of the points in template_center_positions_uv_pix should map to. 
+                These points can be obtained from the photobleaching script.
+            print_inputs: prints to screen the inputs of the function for debug purposes.
+        """
+        # Input check
+        template_positions_uv_pix = np.array(template_positions_uv_pix)
+        template_positions_xyz_mm = np.array(template_positions_xyz_mm)
+        if (template_positions_uv_pix.shape[0] != template_positions_xyz_mm.shape[0]):
+            raise ValueError("Number of points should be the same between " + 
+                "template_center_positions_uv_pix, template_center_positions_xyz_mm")
+        if template_positions_uv_pix.shape[1] != 2:
+            raise ValueError("Number of elements in template_center_positions_uv_pix should be two")
+        if template_positions_xyz_mm.shape[1] != 3:
+            raise ValueError("Number of elements in template_center_positions_xyz_mm should be three")
+        
+        # Print inputs
+        if print_inputs:
+            txt = ("FitPlane.from_template_centers(" +
+                   json.dumps(template_positions_uv_pix.tolist()) + "," +
+                   json.dumps(template_positions_xyz_mm.tolist()))   
+            txt += ')'
+            print(txt)

--- a/plane/fit_plane_elastic.py
+++ b/plane/fit_plane_elastic.py
@@ -56,16 +56,16 @@ class FitPlaneElastic:
         forward_interpolator = RBFInterpolator(
             template_positions_uv_pix,  # 2D source points (uv)
             template_positions_xyz_mm,  # 3D target points (xyz)
-            kernel='thin_plate_spline',  # Use Thin Plate Spline kernel
+            kernel='thin_plate_spline',  
             neighbors=None  # Use all points for interpolation
         )
 
         # Create inverse interpolator (xyz -> uv)
         inverse_interpolator = RBFInterpolator(
             template_positions_xyz_mm[:, :2],  # Use only x and y for inverse (2D)
-            template_positions_uv_pix,  # 2D target points (uv)
-            kernel='thin_plate_spline',  # Use Thin Plate Spline kernel
-            neighbors=None  # Use all points for interpolation
+            template_positions_uv_pix,  
+            kernel='thin_plate_spline', 
+            neighbors=None
         )
 
         # Store control points
@@ -119,19 +119,14 @@ class FitPlaneElastic:
         # Input checks
         x_range_mm = np.array(x_range_mm)
         y_range_mm = np.array(y_range_mm)
-
         if x_range_mm[1] <= x_range_mm[0] or y_range_mm[1] <= y_range_mm[0]:
             raise ValueError("Invalid range: x_range_mm and y_range_mm must be increasing")
-
         if pixel_size_mm <= 0:
             raise ValueError("pixel_size_mm must be positive")
 
         # Calculate image dimensions
         width_px = int((x_range_mm[1] - x_range_mm[0]) / pixel_size_mm)
         height_px = int((y_range_mm[1] - y_range_mm[0]) / pixel_size_mm)
-
-        # Initialize black image
-        transformed_image = np.zeros_like(cv2_image)
 
         # Define the destination grid in physical coordinates
         x_physical = np.linspace(x_range_mm[0], (x_range_mm[1]/pixel_size_mm - 1) * pixel_size_mm, width_px)
@@ -151,9 +146,8 @@ class FitPlaneElastic:
         u_coords = uv_points[:, :, 0]
         v_coords = uv_points[:, :, 1]
 
-        # Handle RGB images
+        # Handle RGB images: Apply map_coordinates to each channel separately
         if len(cv2_image.shape) == 3:
-            # Apply map_coordinates to each channel separately
             warped_channels = [
                 map_coordinates(
                     cv2_image[:, :, channel],  # Extract one channel

--- a/plane/fit_plane_elastic.py
+++ b/plane/fit_plane_elastic.py
@@ -64,3 +64,9 @@ class FitPlaneElastic:
 
         return cls(tps_interpolator, control_points)
     
+    def get_xyz_from_uv(self, uv_pix):
+        """ Map a 2D point (u,v) to 3D (x,y,z) space using TPS interpolation. """
+        uv_pix = np.array(uv_pix)
+        xyz = self.tps_interpolator(uv_pix)  # Add batch dimension
+        return xyz
+  

--- a/plane/test_fit_plane_elastic.py
+++ b/plane/test_fit_plane_elastic.py
@@ -14,6 +14,3 @@ class TestFitPlaneElastic(unittest.TestCase):
     def test_main_function_runs(self):
         FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=False)
         FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=True)
-
-    # def test_fit_mapping(self):
-    #     fp = FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=False)

--- a/plane/test_fit_plane_elastic.py
+++ b/plane/test_fit_plane_elastic.py
@@ -20,7 +20,7 @@ class TestFitPlaneElastic(unittest.TestCase):
         FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=False)
         FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=True)
 
-    def test_get_xyz_from_uv(self):
+    def test_get_xy_from_uv(self):
         fp = FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=False)
         xyz = fp.get_xyz_from_uv(self.template_center_positions_uv_pix)
         npt.assert_array_almost_equal(xyz, self.template_center_positions_xyz_mm)
@@ -103,3 +103,29 @@ class TestFitPlaneElastic(unittest.TestCase):
         self.assertAlmostEqual(random_image[0,0,0],mapped_image[0,0,0])
         self.assertAlmostEqual(random_image[10,10,1],mapped_image[10,10,1])
         self.assertAlmostEqual(random_image[50,50,2],mapped_image[50,50,2])
+
+    def test_image_to_physical_translations_uv(self):
+        # Create dummy plane with a random image
+        uv = [[0,0],[100,0],[0,300]] # pix
+        xyz = [[0,0,0],[1,0,0],[0,3,0]] # mm
+        fp1 = FitPlaneElastic.from_points(uv,xyz)
+
+        # Slightly different plane shifted over by 10
+        uv = [[10,0],[110,0],[10,300]] # pix
+        xyz = [[0,0,0],[1,0,0],[0,3,0]] # mm
+        fp2 = FitPlaneElastic.from_points(uv,xyz)
+
+        np.random.seed(42)
+        blank = np.zeros((300, 100, 3))
+        blank[50,50] = np.array([255,255,255])
+        blank[20,70] = np.array([255,0,0])
+
+        fp1_image = fp1.image_to_physical(blank, [0,1], [0,1], 0.01)
+        fp2_image = fp2.image_to_physical(blank, [0,1], [0,1], 0.01)
+
+        # self.show_image(fp1_image)
+        # self.show_image(fp2_image)
+
+        # Find the position of the white pixel and make sure it is in the correct place
+        npt.assert_array_almost_equal(fp1_image[50,50], [255,255,255])
+        npt.assert_array_almost_equal(fp2_image[50,40], [255,255,255])

--- a/plane/test_fit_plane_elastic.py
+++ b/plane/test_fit_plane_elastic.py
@@ -14,3 +14,8 @@ class TestFitPlaneElastic(unittest.TestCase):
     def test_main_function_runs(self):
         FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=False)
         FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=True)
+
+    def test_get_xyz_from_uv(self):
+        fp = FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=False)
+        xyz = fp.get_xyz_from_uv(self.template_center_positions_uv_pix)
+        npt.assert_array_almost_equal(xyz, self.template_center_positions_xyz_mm)

--- a/plane/test_fit_plane_elastic.py
+++ b/plane/test_fit_plane_elastic.py
@@ -11,6 +11,11 @@ class TestFitPlaneElastic(unittest.TestCase):
         self.template_center_positions_uv_pix = [[0, 1], [1, 0], [1, 1], [0.5, 0.5]]
         self.template_center_positions_xyz_mm = [[0, 1, 0], [1, 0, 0], [1, 1, 0], [0.5, 0.5, 0]]
 
+    def show_image(self, image): # Use for debugging
+        cv2.imshow('Image', image)
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
+
     def test_main_function_runs(self):
         FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=False)
         FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=True)
@@ -19,3 +24,61 @@ class TestFitPlaneElastic(unittest.TestCase):
         fp = FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=False)
         xyz = fp.get_xyz_from_uv(self.template_center_positions_uv_pix)
         npt.assert_array_almost_equal(xyz, self.template_center_positions_xyz_mm)
+
+    def test_image_to_physical_translations_xy(self):
+        # Create dummy plane with a random image
+        uv = [[0,0],[100,0],[0,300], [100,300]] # pix
+        xyz = [[0,0,0],[1,0,0],[0,3,0], [1,3,0]] # mm
+        fp = FitPlaneElastic.from_points(uv,xyz)
+        np.random.seed(42)
+        random_image = np.random.randint(0, 256, (300, 100, 3), dtype=np.uint8) # 100 by 300 noise
+
+        # Map that image to the right, see that filled with black
+        mapped_image = fp.image_to_physical(random_image, x_range_mm=[-0.1,0.9], y_range_mm=[0,3], pixel_size_mm=1e-2)
+        # self.show_image(mapped_image) # uncomment for debug
+        self.assertAlmostEqual(mapped_image[0,0,0],0)
+        self.assertAlmostEqual(mapped_image[0,0,1],0)
+        self.assertAlmostEqual(mapped_image[0,0,2],0)
+        self.assertAlmostEqual(mapped_image[11,0,0],0)
+        self.assertGreater(mapped_image[10,30,0],0) # Area which shouldn't be effected
+
+        # Map that image to the left, see that filled with black
+        mapped_image = fp.image_to_physical(random_image, x_range_mm=[0.1,1.1], y_range_mm=[0,3], pixel_size_mm=1e-2)
+        # self.show_image(mapped_image) # uncomment for debug
+        self.assertAlmostEqual(mapped_image[0,100-5,0],0)
+        self.assertAlmostEqual(mapped_image[0,100-5,1],0)
+        self.assertAlmostEqual(mapped_image[0,100-5,2],0)
+        self.assertAlmostEqual(mapped_image[10,100-5,0],0)
+        self.assertGreater(mapped_image[10,100-11,0],0) # Area which shouldn't be effected
+
+        # Map that image down, see that filled with black
+        mapped_image = fp.image_to_physical(random_image, x_range_mm=[0,1], y_range_mm=[-0.1,2.9], pixel_size_mm=1e-2)
+        # self.show_image(mapped_image) # uncomment for debug
+        self.assertAlmostEqual(mapped_image[0,0,0],0)
+        self.assertAlmostEqual(mapped_image[0,0,1],0)
+        self.assertAlmostEqual(mapped_image[0,0,2],0)
+        self.assertAlmostEqual(mapped_image[0,11,0],0)
+        self.assertGreater(mapped_image[30,11,0],0) # Area which shouldn't be effected
+
+        # Map that image up, see that filled with black
+        mapped_image = fp.image_to_physical(random_image, x_range_mm=[0,1], y_range_mm=[0.1,3.1], pixel_size_mm=1e-2)
+        # self.show_image(mapped_image) # uncomment for debug
+        self.assertAlmostEqual(mapped_image[300-5,0,0],0)
+        self.assertAlmostEqual(mapped_image[300-5,0,1],0)
+        self.assertAlmostEqual(mapped_image[300-5,0,2],0)
+        self.assertAlmostEqual(mapped_image[300-5,10,0],0)
+        self.assertGreater(mapped_image[300-11,10,0],0) # Area which shouldn't be effected
+
+        # Map that image up, see that filled with black
+        mapped_image = fp.image_to_physical(random_image, x_range_mm=[0,1], y_range_mm=[0.1,3.1], pixel_size_mm=1e-2)
+        # self.show_image(mapped_image) # uncomment for debug
+        self.assertAlmostEqual(mapped_image[300-5,0,0],0)
+        self.assertAlmostEqual(mapped_image[300-5,0,1],0)
+        self.assertAlmostEqual(mapped_image[300-5,0,2],0)
+        self.assertAlmostEqual(mapped_image[300-5,10,0],0)
+        self.assertGreater(mapped_image[300-11,10,0],0) # Area which shouldn't be effected
+
+        # Shift to arbitrary point
+        mapped_image = fp.image_to_physical(random_image, x_range_mm=[0.2,1.2], y_range_mm=[0.1,3.1], pixel_size_mm=1e-2)
+        # self.show_image(mapped_image) # uncomment for debug
+        self.assertAlmostEqual(mapped_image[0,0,0],random_image[10,20,0])

--- a/plane/test_fit_plane_elastic.py
+++ b/plane/test_fit_plane_elastic.py
@@ -1,0 +1,19 @@
+import math
+import numpy as np
+import numpy.testing as npt
+import unittest
+from plane.fit_plane_elastic import FitPlaneElastic
+import cv2
+
+class TestFitPlaneElastic(unittest.TestCase):
+
+    def setUp(self):
+        self.template_center_positions_uv_pix = [[0, 1], [1, 0], [1, 1], [0.5, 0.5]]
+        self.template_center_positions_xyz_mm = [[0, 1, 0], [1, 0, 0], [1, 1, 0], [0.5, 0.5, 0]]
+
+    def test_main_function_runs(self):
+        FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=False)
+        FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=True)
+
+    # def test_fit_mapping(self):
+    #     fp = FitPlaneElastic.from_points(self.template_center_positions_uv_pix, self.template_center_positions_xyz_mm, print_inputs=False)

--- a/plane/test_fit_plane_elastic.py
+++ b/plane/test_fit_plane_elastic.py
@@ -82,3 +82,24 @@ class TestFitPlaneElastic(unittest.TestCase):
         mapped_image = fp.image_to_physical(random_image, x_range_mm=[0.2,1.2], y_range_mm=[0.1,3.1], pixel_size_mm=1e-2)
         # self.show_image(mapped_image) # uncomment for debug
         self.assertAlmostEqual(mapped_image[0,0,0],random_image[10,20,0])
+
+    def test_image_to_physical_output_size(self):
+        # Create dummy plane with a random image
+        uv = [[0,0],[100,0],[0,300]] # pix
+        xyz = [[0,0,0],[1,0,0],[0,3,0]] # mm
+        fp = FitPlaneElastic.from_points(uv,xyz)
+        random_image = np.random.randint(0, 256, (300, 100, 3), dtype=np.uint8) # 100 by 300 noise
+
+        # Map that image to physical space
+        mapped_image = fp.image_to_physical(random_image, x_range_mm=[-0.5,0.5], y_range_mm=[-1,1], pixel_size_mm=1e-3)
+        y_size, x_size, _ = mapped_image.shape
+
+        # Verify size is correct
+        self.assertEqual(y_size,2*1/1e-3)
+        self.assertEqual(x_size,2*0.5/1e-3)
+
+        # Map that image to physical space (no mapping), see that pixel values are the same
+        mapped_image = fp.image_to_physical(random_image, x_range_mm=[0,1], y_range_mm=[0,3], pixel_size_mm=1e-2)
+        self.assertAlmostEqual(random_image[0,0,0],mapped_image[0,0,0])
+        self.assertAlmostEqual(random_image[10,10,1],mapped_image[10,10,1])
+        self.assertAlmostEqual(random_image[50,50,2],mapped_image[50,50,2])


### PR DESCRIPTION
1) Function to get a single xyz coordinate from a uv point.
2) Function to map entire image, using separately computed forward and reverse TPS functions.
3) Passes test cases adapted from original fit_plane tests as well as looking good visually. TPS is able to capture pure affine transforms such as translations.