### PR TITLE
Pcr99a helper functions

### DIFF
--- a/PCR99a.py
+++ b/PCR99a.py
@@ -24,3 +24,41 @@ def sRt_from_N_points(A, B):
     t = centroid_B.flatten() - s * R @ centroid_A.flatten()
 
     return s, R, t
+
+def _score_correspondences(log_ratio_mat, thr1):
+        """
+        Step 2 of PCR99a.
+        Args:
+            log_ratio_mat: (n, n) matrix
+            thr1: clipping threshold
+
+        Returns:
+            min_costs: (n,) array of minimum costs per row
+        """
+        n = log_ratio_mat.shape[0]
+        min_costs = np.full(n, np.inf)
+
+        for i in range(n):
+            lr_mat = log_ratio_mat[i, :]
+            max_lr, min_lr = np.nanmax(lr_mat), np.nanmin(lr_mat)
+            lr_range = max_lr - min_lr
+            lr_step = lr_range / max(1, round(lr_range / 0.1))
+
+            lr_candidates = np.arange(min_lr, max_lr + lr_step/2, lr_step)  # inclusive range
+
+            # Broadcast: residuals shape = (num_candidates, n)
+            r = np.abs(lr_mat[None, :] - lr_candidates[:, None])
+            r = np.minimum(r, thr1)  # clip
+
+            # Cost for each candidate = sum across columns
+            costs = np.nansum(r, axis=1)
+            min_costs[i] = np.nanmin(costs)
+        return min_costs
+
+def run_PCR99a():
+    # 1. Pairwise squared distance, log ratio matrix
+
+    # 2. Score correspondence pairs
+
+    # 3. RANSAC round 1
+    pass

--- a/PCR99a.py
+++ b/PCR99a.py
@@ -1,0 +1,68 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+def sRt_from_3points(A, B):
+    """
+    Compute scale (s), rotation (R), translation (t) from 3 point pairs.
+    A: (3,3) ground truth points
+    B: (3,3) estimated points
+    """
+    centroid_A = np.mean(A, axis=1, keepdims=True)
+    centroid_B = np.mean(B, axis=1, keepdims=True)
+
+    A_c = A - centroid_A
+    B_c = B - centroid_B
+
+    # Axes for B
+    v12 = B_c[:, 1] - B_c[:, 0]
+    x_axis = v12 / np.linalg.norm(v12)
+    v13 = B_c[:, 2] - B_c[:, 0]
+    v23 = np.cross(v12, v13)
+    y_axis = v23 / np.linalg.norm(v23)
+    z_axis = np.cross(x_axis, y_axis)
+    z_axis /= np.linalg.norm(z_axis)
+
+    # Axes for A
+    v12 = A_c[:, 1] - A_c[:, 0]
+    x_axis_ = v12 / np.linalg.norm(v12)
+    v13 = A_c[:, 2] - A_c[:, 0]
+    v23 = np.cross(v12, v13)
+    y_axis_ = v23 / np.linalg.norm(v23)
+    z_axis_ = np.cross(x_axis_, y_axis_)
+    z_axis_ /= np.linalg.norm(z_axis_)
+
+    R = np.column_stack([x_axis, y_axis, z_axis]) @ np.column_stack([x_axis_, y_axis_, z_axis_]).T
+
+    # Scale
+    num = sum(B_c[:, i].T @ R @ A_c[:, i] for i in range(A.shape[1]))
+    den = sum(A_c[:, i].T @ A_c[:, i] for i in range(A.shape[1]))
+    s = num / den
+
+    # Translation
+    t = centroid_B.flatten() - s * R @ centroid_A.flatten()
+
+    return s, R, t
+
+def sRt_from_N_points(A, B):
+    """
+    Compute scale (s), rotation (R), translation (t) from N point pairs.
+    A: (3,n) ground truth points
+    B: (3,n) estimated points
+    """
+    centroid_A = np.mean(A, axis=1, keepdims=True)
+    centroid_B = np.mean(B, axis=1, keepdims=True)
+
+    A_c = A - centroid_A
+    B_c = B - centroid_B
+
+    U, _, Vh = np.linalg.svd(A_c @ B_c.T)
+    V = Vh.T
+    R = V @ np.diag([1, 1, np.sign(np.linalg.det(V @ U.T))]) @ U.T
+
+    num = sum(B_c[:, i].T @ R @ A_c[:, i] for i in range(A.shape[1]))
+    den = sum(A_c[:, i].T @ A_c[:, i] for i in range(A.shape[1]))
+    s = num / den
+
+    t = centroid_B.flatten() - s * R @ centroid_A.flatten()
+
+    return s, R, t

--- a/PCR99a.py
+++ b/PCR99a.py
@@ -1,48 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-def sRt_from_3points(A, B):
-    """
-    Compute scale (s), rotation (R), translation (t) from 3 point pairs.
-    A: (3,3) ground truth points
-    B: (3,3) estimated points
-    """
-    centroid_A = np.mean(A, axis=1, keepdims=True)
-    centroid_B = np.mean(B, axis=1, keepdims=True)
-
-    A_c = A - centroid_A
-    B_c = B - centroid_B
-
-    # Axes for B
-    v12 = B_c[:, 1] - B_c[:, 0]
-    x_axis = v12 / np.linalg.norm(v12)
-    v13 = B_c[:, 2] - B_c[:, 0]
-    v23 = np.cross(v12, v13)
-    y_axis = v23 / np.linalg.norm(v23)
-    z_axis = np.cross(x_axis, y_axis)
-    z_axis /= np.linalg.norm(z_axis)
-
-    # Axes for A
-    v12 = A_c[:, 1] - A_c[:, 0]
-    x_axis_ = v12 / np.linalg.norm(v12)
-    v13 = A_c[:, 2] - A_c[:, 0]
-    v23 = np.cross(v12, v13)
-    y_axis_ = v23 / np.linalg.norm(v23)
-    z_axis_ = np.cross(x_axis_, y_axis_)
-    z_axis_ /= np.linalg.norm(z_axis_)
-
-    R = np.column_stack([x_axis, y_axis, z_axis]) @ np.column_stack([x_axis_, y_axis_, z_axis_]).T
-
-    # Scale
-    num = sum(B_c[:, i].T @ R @ A_c[:, i] for i in range(A.shape[1]))
-    den = sum(A_c[:, i].T @ A_c[:, i] for i in range(A.shape[1]))
-    s = num / den
-
-    # Translation
-    t = centroid_B.flatten() - s * R @ centroid_A.flatten()
-
-    return s, R, t
-
 def sRt_from_N_points(A, B):
     """
     Compute scale (s), rotation (R), translation (t) from N point pairs.

--- a/test_PCR99a.py
+++ b/test_PCR99a.py
@@ -1,0 +1,41 @@
+import numpy as np
+import numpy.testing as npt
+import unittest
+
+from PCR99a import sRt_from_N_points
+
+class TestFitPlaneElastic(unittest.TestCase):
+
+    def setUp(self):
+        np.random.seed(42)
+
+        n_pts = 20
+        self.P = np.random.rand(3,n_pts)
+        self.s = 1.2
+
+        alpha = np.pi/18 # 10 degrees
+        self.R = np.array([
+            [1, 0, 0],
+            [0, np.cos(alpha), -np.sin(alpha)],
+            [0, np.sin(alpha),  np.cos(alpha)]
+        ])
+        # self.t = np.array([[1], [-2], [3]])
+        self.t = np.array([1,-2,3])
+        self.Q = self.s * (self.R @ self.P) + self.t.reshape((3,1))
+
+    def test_main_function_runs(self):
+        # TODO
+        pass
+    
+    def test_sRt_3points(self):
+        s,R,t = sRt_from_N_points(self.P[:,3], self.Q[:,3])
+        self.assertAlmostEqual(s, self.s)
+        npt.assert_allclose(R, self.R, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(t, self.t, rtol=1e-4, atol=1e-4)
+
+    def test_sRt_3points(self):
+        s,R,t = sRt_from_N_points(self.P, self.Q)
+        self.assertAlmostEqual(s, self.s)
+        npt.assert_allclose(R, self.R, rtol=1e-4, atol=1e-4)
+        npt.assert_allclose(t, self.t, rtol=1e-4, atol=1e-4)
+

--- a/test_PCR99a.py
+++ b/test_PCR99a.py
@@ -4,7 +4,7 @@ import unittest
 
 from PCR99a import sRt_from_N_points
 
-class TestFitPlaneElastic(unittest.TestCase):
+class TestPCR99a(unittest.TestCase):
 
     def setUp(self):
         np.random.seed(42)

--- a/test_PCR99a.py
+++ b/test_PCR99a.py
@@ -2,7 +2,7 @@ import numpy as np
 import numpy.testing as npt
 import unittest
 
-from PCR99a import sRt_from_N_points
+from PCR99a import sRt_from_N_points, _score_correspondences
 
 class TestPCR99a(unittest.TestCase):
 
@@ -22,20 +22,31 @@ class TestPCR99a(unittest.TestCase):
         # self.t = np.array([[1], [-2], [3]])
         self.t = np.array([1,-2,3])
         self.Q = self.s * (self.R @ self.P) + self.t.reshape((3,1))
-
-    def test_main_function_runs(self):
-        # TODO
-        pass
     
     def test_sRt_3points(self):
-        s,R,t = sRt_from_N_points(self.P[:,3], self.Q[:,3])
+        s,R,t = sRt_from_N_points(self.P[:,:3], self.Q[:,:3])
         self.assertAlmostEqual(s, self.s)
         npt.assert_allclose(R, self.R, rtol=1e-4, atol=1e-4)
         npt.assert_allclose(t, self.t, rtol=1e-4, atol=1e-4)
 
-    def test_sRt_3points(self):
+    def test_sRt_Npoints(self):
         s,R,t = sRt_from_N_points(self.P, self.Q)
         self.assertAlmostEqual(s, self.s)
         npt.assert_allclose(R, self.R, rtol=1e-4, atol=1e-4)
         npt.assert_allclose(t, self.t, rtol=1e-4, atol=1e-4)
+
+    def test_step2(self):
+        # Known test result from Matlab version
+        vals = np.array([
+            2.33721474e-08, 5.31067768e-09, 3.21212928e-08, 9.81710382e-09
+        ])
+        log_ratios = np.array([
+            [np.nan,       -0.18232156, -0.18232158, -0.18232156],
+            [-0.18232156,  np.nan,      -0.18232155, -0.18232155],
+            [-0.18232158, -0.18232155,  np.nan,      -0.18232156],
+            [-0.18232156, -0.18232155, -0.18232156,  np.nan]
+        ])
+
+        min_costs = _score_correspondences(log_ratios, 0.03)
+        npt.assert_allclose(min_costs, vals, rtol=1e-7, atol=1e-7)
 


### PR DESCRIPTION
Two helper functions for PCR99a, translated from matlab. Testers included, and outputs are compared to the Matlab version. 